### PR TITLE
Add EditorConfig file to keep things consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix line endings
+[*]
+end_of_line = lf
+
+# 4 space indentation for every file
+indent_style = space
+indent_size = 4
+
+# Except for in Makefiles
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
http://editorconfig.org/

Most text editors either look for .editorconfig automatically, or can be told to with a plugin. It should keep our tabs/space conflicts to a minimum.