### PR TITLE
fix uefi bootloader issue

### DIFF
--- a/sources/anaconda-installclass-tigeros/tigeros.py
+++ b/sources/anaconda-installclass-tigeros/tigeros.py
@@ -33,7 +33,7 @@ class TigerOSBaseInstallClass(BaseInstallClass):
 
     _l10n_domain = "anaconda"
 
-    efi_dir = "tigeros"
+    efi_dir = "fedora"
 
     help_placeholder = "TigerOSPlaceholder.html"
     help_placeholder_plain_text = "TigerOSPlaceholder.txt"


### PR DESCRIPTION
This forces `grub2-mkconfig` to use `/boot/efi/EFI/fedora` to install UEFI entries, rather than the nonexistent `/boot/efi/EFI/tigeros`. This fixes the bootloader install issue #58 . No visual change occurs: all entries in the UEFI bootup menu still say TigerOS.

However, if we really wanted to use a different directory, we'd need to repackage `grub2-efi`, as the `fedora` directory is included in that package upstream.