### PR TITLE
Update build output path

### DIFF
--- a/build-scripts/ci-build-mock.sh
+++ b/build-scripts/ci-build-mock.sh
@@ -18,15 +18,15 @@ fi
 mock --old-chroot -r fedora-26-x86_64 --init
 mock --old-chroot -r fedora-26-x86_64 --copyin kickstarts/tigeros.ks ./tigeros.ks
 mock --old-chroot -r fedora-26-x86_64 --install lorax-lmc-novirt git vim-minimal pykickstart
-mock --old-chroot -r fedora-26-x86_64 --install https://tigeros.ritlug.com/packages/x86_64/anaconda-installclass-tigeros-26-1.fc26.x86_64.rpm
+mock --old-chroot -r fedora-26-x86_64 --install https://builder.ritlug.com/packages/x86_64/anaconda-installclass-tigeros-26-1.fc26.x86_64.rpm
 mock --old-chroot -r fedora-26-x86_64 --chroot "livemedia-creator --ks tigeros.ks --no-virt --resultdir /var/lmc --project TigerOS-Live --make-iso --volid TigerOS --iso-only --iso-name TigerOS.iso --releasever 26 --title TigerOS-live --macboot"
-rm -rf /usr/share/nginx/html/isos/TigerOS-$(date +%Y%m%d).iso
-mock --old-chroot -r fedora-26-x86_64 --copyout /var/lmc/TigerOS.iso /usr/share/nginx/html/isos/TigerOS-$(date +%Y%m%d).iso 
+rm -rf /var/www/isos/TigerOS-$(date +%Y%m%d).iso
+mock --old-chroot -r fedora-26-x86_64 --copyout /var/lmc/TigerOS.iso /var/www/isos/TigerOS-$(date +%Y%m%d).iso 
 rm -rf /var/lib/mock/
-cd /usr/share/nginx/html/isos
+cd /var/www/isos
 rm -rf CHECKSUM512-$(date +%Y%m%d)
 sha512sum TigerOS-$(date +%Y%m%d).iso > CHECKSUM512-$(date +%Y%m%d) 
-chown -R nginx:nginx /usr/share/nginx/html/
-chmod 755 /usr/share/nginx/html/isos/*.iso
+chown -R nginx:nginx /var/www/
+chmod 755 /var/www/isos/*.iso
 echo "Build finished"
 

--- a/build-scripts/ci-pungi.sh
+++ b/build-scripts/ci-pungi.sh
@@ -18,15 +18,15 @@ fi
 mock --old-chroot -r fedora-26-x86_64 --init
 mock --old-chroot -r fedora-26-x86_64 --copyin kickstarts/tigeros-source.ks ./tigeros-source.ks
 mock --old-chroot -r fedora-26-x86_64 --install pungi
-mock --old-chroot -r fedora-26-x86_64 --install https://tigeros.ritlug.com/packages/x86_64/anaconda-installclass-tigeros-26-1.fc26.x86_64.rpm
+mock --old-chroot -r fedora-26-x86_64 --install https://builder.ritlug.com/packages/x86_64/anaconda-installclass-tigeros-26-1.fc26.x86_64.rpm
 mock --old-chroot -r fedora-26-x86_64 --chroot "pungi -G -c tigeros-source.ks --name=TigerOS --ver 26 --force && pungi -C -c tigeros-source.ks --name=TigerOS --ver=26 --force && pungi -I -c tigeros-source.ks --name=TigerOS --ver=26 --sourceisos --force"
-rm -rf /usr/share/nginx/html/isos/TigerOS-source-$(date +%Y%m%d).iso
-mock --old-chroot -r fedora-26-x86_64 --copyout /26/source/iso/TigerOS-DVD-source-26.iso /usr/share/nginx/html/isos/TigerOS-source-$(date +%Y%m%d).iso 
+rm -rf /var/www/isos/TigerOS-source-$(date +%Y%m%d).iso
+mock --old-chroot -r fedora-26-x86_64 --copyout /26/source/iso/TigerOS-DVD-source-26.iso /var/www/isos/TigerOS-source-$(date +%Y%m%d).iso 
 rm -rf /var/lib/mock/
-cd /usr/share/nginx/html/isos
+cd /var/www/isos
 rm -rf CHECKSUM512-source-$(date +%Y%m%d)
 sha512sum TigerOS-source-$(date +%Y%m%d).iso > CHECKSUM512-source-$(date +%Y%m%d) 
 chown -R nginx:nginx /usr/share/nginx/html
-chmod 755 /usr/share/nginx/html/isos/*.iso
+chmod 755 /var/www/isos/*.iso
 echo "Pungi finished"
 

--- a/sources/tigeros-backgrounds/tigeros-backgrounds-1.0/20_tigeros.gschema.override
+++ b/sources/tigeros-backgrounds/tigeros-backgrounds-1.0/20_tigeros.gschema.override
@@ -1,2 +1,2 @@
-[org.cinnamon.desktop.background]
+[org.gnome.desktop.background]
 picture-uri="file:///usr/share/backgrounds/tigeros/wallpaper2-1920x1080.jpg"


### PR DESCRIPTION
We have decided to serve the ISOs and packages from the standard /var/www directory to avoid issues with SELinux contexts.