### PR TITLE
Add issue, pull request templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+ Contributing
+====================
+
+Please follow the below workflow when contributing to TigerOS. This helps prevent issues when merging your pull requests. 
+
+### Workflow
+1. Fork this repository. 
+2. Create a new branch in your fork for working on your changes.
+3. Submit a pull request with your changes against the devel branch of the RITlug/TigerOS repo.
+
+ Pull requests will be reviewed as time permits.
+
+### Additional Reading
+* [Configuring your Git Environment for TigerOS Development](https://help.github.com/articles/configuring-a-remote-for-a-fork/)
+* [How Git works with GitHub](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project)
+
+### Some things to keep in mind:
+* Due to this being a student run project, there may be a delay in getting a response from the developers.
+* All scripts added to github should have 644 permissions.
+* When possible, please contact the maintainer or creator of a component through a github issue or IRC. The email accounts listed are university accounts and may filter your message as spam. 
+* Please use the editorconfig file when editing files to ensure consistency.
+* Contact ritlug@gmail.com with any questions. Please include the phrase TigerOS in the subject.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,72 @@
+<!--
+    Thanks for filing a new issue on TigerOS! To help us help you, please use
+    this template for filing your bug, feature request, or other topic.
+
+    If you use this template, it helps the developers review your ticket and
+    figure out the problem. If you don't use this template, we may close your
+    issue as not enough information.
+ -->
+
+# Summary
+
+<!--
+    Choose the type of issue you are filing. You can choose one by typing [X]
+    in one of the fields. For example, if a bug report, change the line below
+    to…
+
+    [X] Bug report
+ -->
+
+* This issue is a…
+    * [ ] Bug report
+    * [ ] Feature request
+    * [ ] Other issue
+    * [ ] Question <!-- Please read the wiki first! -->
+* **Describe the issue / feature in 1-2 sentences**: 
+
+
+# Background
+
+<!--
+    This section is very important! First, if you are filing a bug report,
+    DELETE the "Feature request" section. If it's a feature request, DELETE the
+    "Bug report".
+
+    If a bug report, make sure to include all info. This helps us see what
+    you're running and makes it easier to duplicate your problem.
+
+    If a feature request, help us understand your idea. Be descriptive, but
+    also consider any other issues that could happen if it is added. Would it
+    affect other features of MobArena?
+ -->
+
+### Bug report
+
+
+
+### Feature request 
+
+**What does it do?**:
+
+**Does it need new or changed commands? What are they?**:
+
+**Does this feature affect other parts of MobArena?**:
+
+
+# Details
+
+<!--
+    If you have other details to include, like screenshots, stacktraces, or
+    something more detailed, please include it here!
+
+    If you have a long stacktrace, DO NOT PASTE IT HERE! Please use Pastebin
+    and add a link here.
+ -->
+
+* **Stacktrace** (if applicable): 
+
+<!--
+    Phew, all done! Thank you so much for filing a new issue! We'll try to get
+    back to you soon.
+ -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+<!--
+    Hello! Thanks for submitting a pull request to TigerOS. We appreciate
+    your time and interest in helping our project!
+
+    Use this template to help us review your change. Not everything is
+    required, depending on your change. Keep or delete what is relevant for
+    your change. Remember that it helps us review if you give more helpful
+    info for us to understand your change.
+-->
+
+# Summary
+
+<!--
+    Update the checkbox for the type of contribution you are making. For
+    example, if you are filing a bug fix, check the box like this:
+
+    [X] Bug fix
+-->
+
+* This is a…
+    * [ ] Bug fix
+    * [ ] Feature addition
+    * [ ] Refactoring
+    * [ ] Minor / simple change (like a typo)
+    * [ ] Other
+* **Describe this change in 1-2 sentences**:
+
+
+# Problem
+
+<!-- 
+    Anything that helps us understand why you are making this change goes here.
+    What problem are you trying to fix? What does this change address?
+-->
+
+* **GitHub issue** (_optional_): 
+
+
+# Solution
+
+<!--
+    The details of your change. Talk about technical details, considerations,
+    or other interesting points. If you have a lot to say, be more detailed in
+    this section.
+-->
+
+
+# Action
+
+<!--
+    Other than merging your change, do you want / need us to do anything else
+    with your change? This could include reviewing a specific part of your PR.
+-->
+


### PR DESCRIPTION
This PR does three things:

1. Adds a new template for pull requests against TigerOS
2. Adds a new template for issues against TigerOS
3. Moves `CONTRIBUTING.md` into the `.github` directory (since we have a few files now)